### PR TITLE
fix create dir and container image

### DIFF
--- a/bandage/bandage-image.cwl
+++ b/bandage/bandage-image.cwl
@@ -1,19 +1,119 @@
 #!/usr/bin/env cwl-runner
 cwlVersion: v1.0
 class: CommandLineTool
+id: bandage-image
+inputs:
+
+  - id: graph
+    type: File
+    doc: |
+        Graphical Fragment Assembly
+        Supports multiple assembly graph formats: 
+        LastGraph (Velvet), FASTG (SPAdes), Trinity.fasta, ASQG and GFA.
+ 
+
+  - id: format
+    type:  string
+    default: jpg
+    doc: |
+        Produce jpg, png or svg file
+
+
+  - id: height
+    type:  int
+    default: 1000
+    doc: |
+        Image height.If only height or width is set, 
+        the other will be determined automatically.
+        If both are set, the image will be exactly that size.
+
+
+  - id: width
+    type:  int?
+    doc: |
+        Image width. If only height or width is set, the other will be determined automatically.
+        If both are set, the image will be exactly that size.
+
+
+  - id: node_name
+    type:  boolean
+    default: true
+    doc: |
+        If true, define Node labels as name 
+
+  - id: node_length
+    type:  boolean
+    default: true
+    doc: |
+        If true, define Node labels as length 
+
+
+outputs:
+
+
+# - id: all_script
+#   type:
+#      - type: array
+#        items: File
+#   outputBinding:
+#      glob: "*.sh"  
+#   doc: "generated script to run bandage. for learning purpose" 
+
+
+ - id: image
+   type: File
+   outputBinding:
+      glob: "*.$(inputs.format)"
+   doc: "Assembly Graph Image"
+
+
+
+
+baseCommand: bash
+
+arguments: [bandage_image_launch.sh]
 
 hints:
   DockerRequirement:
-    dockerPull: biocontainers/bandage:v0.8.1-1-deb_cv1
+    dockerPull: "fjrmore/bandage" 
+
 
 requirements:
-  EnvVarRequirement:
-    envDef:
-      XDG_RUNTIME_DIR: $(runtime.tmpdir)
-      QT_QPA_PLATFORM: minimal
+  - class:  InlineJavascriptRequirement
+  - class: InitialWorkDirRequirement
+    listing:
+      - entryname: bandage_image_launch.sh
+        entry: |
+               #!/bin/bash
+               ###########################
+               # Bandage image wrapper  
+               export QT_QPA_PLATFORM=minimal
+               TMPDIR=$PWD"/tmp_runtime-bandage"
+               mkdir -p $TMPDIR
+               export XDG_RUNTIME_DIR=$TMPDIR
+               GRAPH="$(inputs.graph.path)"
+               IMAGE="$(inputs.graph.nameroot).$(inputs.format)"
+               Bandage image $GRAPH $IMAGE  \\
+               ${
+                var opt=""
+                if(inputs.height!=null){ 
+                 opt+=" --height "+inputs.height+ " "
+                }
+                if(inputs.width!=null){ 
+                 opt+=" --width "+inputs.width +" "
+                }
+                if(inputs.node_length==true){ 
+                 opt+=" --names "
+                }
+                if(inputs.node_length==true){ 
+                 opt+=" --lengths "
+                }
+                return opt
+               }  
 
-label: Bandage image
+
 doc: |
+  CWL  tool for Bandage-info.
   an hybrid assembly pipeline for bacterial genomes
   *Bandage Overview**
   Bandage is a GUI program that allows users to interact with the assembly graphs made by de novo assemblers 
@@ -27,70 +127,3 @@ doc: |
   Bandage works with Graphical Fragment Assembly (GFA) files. 
   For more information about this file format, see https://gfa-spec.github.io/GFA-spec/GFA2.html
 
-baseCommand: [ Bandage, image ]
-
-inputs:
-  graph:
-    type: File
-    doc: |
-        Graphical Fragment Assembly
-        Supports multiple assembly graph formats: 
-        LastGraph (Velvet), FASTG (SPAdes), Trinity.fasta, ASQG and GFA.
-    inputBinding:
-      position: 1
-
-  format:
-    type:
-      - 'null'
-      - type: enum
-        symbols:
-          - jpg
-          - png
-          - svg
-    default: jpg
-    inputBinding:
-      position: 2
-      valueFrom: $(inputs.graph.nameroot).$(self) 
-    doc: |
-        Produce jpg, png or svg file
-
-  height:
-    type: int
-    default: 1000
-    inputBinding:
-      prefix: --height
-    doc: |
-        Image height.If only height or width is set, 
-        the other will be determined automatically.
-        If both are set, the image will be exactly that size.
-
-  width:
-    inputBinding:
-      prefix: --width
-    type:  int?
-    doc: |
-        Image width. If only height or width is set, the other will be determined automatically.
-        If both are set, the image will be exactly that size.
-
-  node_name:
-    type:  boolean
-    default: true
-    doc: |
-        If true, define Node labels as name 
-
-  node_length:
-    type:  boolean
-    default: true
-    inputBinding:
-      prefix: --names
-      valueFrom: --length
-    doc: |
-        If true, define Node labels as length 
-
-
-outputs:
- image:
-   type: File
-   outputBinding:
-      glob: $(inputs.graph.nameroot).$(inputs.format)
-   doc: "Assembly Graph Image"

--- a/bandage/bandage-info.cwl
+++ b/bandage/bandage-info.cwl
@@ -1,19 +1,83 @@
 #!/usr/bin/env cwl-runner
 cwlVersion: v1.0
 class: CommandLineTool
+id: bandage-info
+inputs:
+
+  - id: graph
+    type:  File
+    doc: |
+        Graphical Fragment Assembly.
+        Supports multiple
+        assembly graph formats: 
+        LastGraph (Velvet), FASTG (SPAdes), Trinity.fasta, ASQG and GFA.    
+
+
+  - id: tsv
+    type:  boolean
+    default: false
+    doc: |
+        If true, output the information in a single tab-delimited line 
+        starting with the graph file
+
+
+
+
+
+outputs:
+
+# - id: all_script
+#   type:
+#      - type: array
+#        items: File
+#   outputBinding:
+#      glob: "*.sh"  
+#   doc: "generated script to run bandage. for learning purpose" 
+
+ - id: assembly_graph_info
+   type: File
+   outputBinding:
+      glob: "assembly_graph_info.txt"
+   doc: "Assembly Graph Information"
+
+
+
+
+baseCommand: bash
+
+arguments: [bandage_info_launch.sh]
 
 hints:
   DockerRequirement:
-    dockerPull: biocontainers/bandage:v0.8.1-1-deb_cv1
+    dockerPull: "fjrmore/bandage" 
+
 
 requirements:
-  EnvVarRequirement:
-    envDef:
-      XDG_RUNTIME_DIR: $(runtime.tmpdir)
-      QT_QPA_PLATFORM: minimal
+  - class:  InlineJavascriptRequirement
+  - class: InitialWorkDirRequirement
+    listing:
+      - entryname: bandage_info_launch.sh
+        entry: |
+               #!/bin/bash
+               ###########################
+               # Bandage info wrapper  
+               export QT_QPA_PLATFORM=minimal
+               TMPDIR=$PWD"/tmp_runtime-bandage"
+               mkdir -p $TMPDIR
+               export XDG_RUNTIME_DIR=$TMPDIR
+               Bandage info '$(inputs.graph.path)' \\
+               ${
+                var opt=""
+                if(inputs.tsv==true){ 
+                 opt+=" --tsv "
+                }
+                return opt
+               } \\
+                > assembly_graph_info.txt
 
-label: Bandage info
+
 doc: |
+  CWL  tool for Bandage-info.
   an hybrid assembly pipeline for bacterial genomes
   *Bandage Overview**
   Bandage is a GUI program that allows users to interact with the assembly graphs made by de novo assemblers 
@@ -26,31 +90,4 @@ doc: |
   that are not possible by looking at contigs alone. 
   Bandage works with Graphical Fragment Assembly (GFA) files. 
   For more information about this file format, see https://gfa-spec.github.io/GFA-spec/GFA2.html
-
-baseCommand: [ Bandage, info ]
-
-inputs:
-  graph:
-    type: File
-    doc: |
-        Graphical Fragment Assembly
-        Supports multiple assembly graph formats: 
-        LastGraph (Velvet), FASTG (SPAdes), Trinity.fasta, ASQG and GFA.
-    inputBinding:
-      position: 1
-
-  tsv:
-    type: boolean
-    inputBinding:
-      prefix: --tsv
-    doc: |
-        If true, output the information in a single tab-delimited line 
-        starting with the graph file
-
-stdout: assembly_graph_info.txt
-
-outputs:
- assembly_graph_info:
-   type: stdout
-   doc: "Assembly Graph Information"
 


### PR DESCRIPTION
 the bandage tools are broken (image +info)
 the tests scripts are here : https://github.com/fjrmoreews/cwl-workflow-SARS-CoV-2/tree/master/Assembly/bandage/test . 

the issues are related to 
1/ XDG_RUNTIME_DIR: $(runtime.tmpdir) dir not created . 

2/ container from biocontainer (not working ?) so I created one after testing the biocontainer one's.
I 'm going to email the biocontainer's container designer as well
