### PR TITLE
Update BWA tools to better handle secondaryFiles

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Styleguide
 
+See also https://www.commonwl.org/user_guide/rec-practices/
+
 ## Naming Tools 📛
 
 Tools should follow the convention of being prefixed by the parent tool name and Camelcase like so i.e.

--- a/bwa/BWA-Index.cwl
+++ b/bwa/BWA-Index.cwl
@@ -13,14 +13,14 @@ inputs:
     format: edam:format_1929  # FASTA
     inputBinding:
       position: 200
-    
+
   IndexName:
     type: string
     inputBinding:
       prefix: "-p"
-      valueFrom: $(self + ".bwt")
 
 #Optional arguments
+
 
   algoType:
     type: 
@@ -38,8 +38,14 @@ outputs:
 
   index:
     type: File
+    secondaryFiles: |
+      ${
+        return [".amb", ".ann", ".pac", ".sa"].map(function(element) {
+          return self.basename.replace(/\.[^/.]+$/, "") + element;
+        });
+      }
     outputBinding:
-      glob: $(inputs.IndexName)
+      glob: $(inputs.IndexName + '.bwt')  
 
 $namespaces:
   edam: http://edamontology.org/

--- a/bwa/BWA-Mem.cwl
+++ b/bwa/BWA-Mem.cwl
@@ -5,6 +5,7 @@ class: CommandLineTool
 requirements:
   DockerRequirement:
     dockerPull: "quay.io/biocontainers/bwa:0.7.17--ha92aebf_3"
+  InlineJavascriptRequirement: {}
 
 inputs:
   InputFile:
@@ -17,16 +18,13 @@ inputs:
     
   Index:
     type: File
-    inputBinding:
-      position: 200
-    secondaryFiles:
-      - .fai
-      - .amb
-      - .ann
-      - .bwt
-      - .pac
-      - .sa
-
+    secondaryFiles: |
+      ${
+        return [".amb", ".ann", ".pac", ".sa"].map(function(element) {
+          return self.basename.replace(/\.[^/.]+$/, "") + element;
+        });
+      }    
+    
 #Optional arguments
 
   Threads:
@@ -121,6 +119,13 @@ inputs:
       
 
 baseCommand: [bwa, mem]
+arguments:
+  - valueFrom: |
+      ${
+        return inputs.Index.path.replace(/\.bwt$/, "")
+      }
+    position: 200
+    
 
 stdout: unsorted_reads.sam
 


### PR DESCRIPTION
`bwa` identifies an indexed database by base name but the actual DB consists of 5 files with extensions `amb`, `ann`, `bwt`, `pac` and `sa`. This means that for such a database to propagate through a workflow it needs to choose one of those files and have the others as secondaryFiles. The current version of the `bwa Index` tool identifies the `.bwt` file as the index, and the `bwa mem` tool identifies a base file (presumably the fasta source of the index) along with the above mentioned 5 files and a `.fai` file (the output of `samtools index`).

This PR uses a Javascript expression to compute the collection of files that make up the index by identifying the `bwt` as the main file and replacing the `bwt` extension with the 4 other necessary extensions as secondaryFiles. It then uses the same logic the tool for `bwa index`. A workflow using the two tools could be as follows:

```cwl
cwlVersion: v1.0
class: Workflow
requirements:
  StepInputExpressionRequirement: {}
  InlineJavascriptRequirement: {}

inputs:
  reads: File[]
  genome: File
outputs:
  mapped_reads:
    type: File
    outputSource: bwa_mem/reads_stdout

steps:
  bwa_index:
    run: BWA-Index.cwl
    in:
      InputFile: genome
      IndexName:
        source: genome
        valueFrom: $(self.basename)
    out: [index]
  bwa_mem:
    run: BWA-Mem.cwl
    in:
      InputFile: reads
      Index: bwa_index/index
    out: [reads_stdout]

$namespaces:
  edam: http://edamontology.org/
$schemas:
  - http://edamontology.org/EDAM_1.18.owl
```