### PR TITLE
Add link to Code of Conduct

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,10 @@
-# Styleguide
+## Styleguide
 
 See also https://www.commonwl.org/user_guide/rec-practices/
+
+## Code of Conduct
+
+Contributor to this repository should abide by the Common Workflow Language [Code of Conduct](https://github.com/common-workflow-language/common-workflow-language/blob/main/CODE_OF_CONDUCT.md)
 
 ## Getting started
 


### PR DESCRIPTION
Add a link to the CWL project Code of Conduct to clarify that that applies here too.