### PR TITLE
Update nextclade to 0.11.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ contribution tips. Thank you for your contribution!
 
 3. Use the in-development [CWL Dependency Manager](https://github.com/common-workflow-language/cwldep).
 
+4. Refering to the tools in this repository by URL, as in this [example](https://github.com/pvanheus/lukasa/blob/main/protein_evidence_mapping.cwl#L29) which uses a [namespace](https://github.com/pvanheus/lukasa/blob/main/protein_evidence_mapping.cwl#L89) to refer to the `bio-cwl-tools` repository and then specifies in the individual tool by path within that namespace prefix. If this route is used, `cwltool --pack` can created a runnable version of the workflow with all remote references resolved.
+
 
 # Contributors ✨
 

--- a/nextclade/nextclade.cwl
+++ b/nextclade/nextclade.cwl
@@ -13,7 +13,7 @@ s:author:
 
 requirements:
   DockerRequirement:
-    dockerPull: neherlab/nextclade:0.10.0-alpine
+    dockerPull: neherlab/nextclade:0.11.1-alpine
 
 hints:
   ResourceRequirement:


### PR DESCRIPTION
Update nextclade to follow upstream development, especially with regards to [new naming scheme](https://nextstrain.org/blog/2021-01-06-updated-SARS-CoV-2-clade-naming).