### PR TITLE
Correct typo in trim_galore.cwl

### DIFF
--- a/trim_galore/trim_galore.cwl
+++ b/trim_galore/trim_galore.cwl
@@ -110,7 +110,7 @@ arguments:
   - prefix: --adapter
     valueFrom: |
       ${
-        if ( inputs.apdater1 != null && inputs.adapter1 != "illumina" && inputs.adapter1 != "nextera" && inputs.adapter1 != "small_rna" ){
+        if ( inputs.adapter1 != null && inputs.adapter1 != "illumina" && inputs.adapter1 != "nextera" && inputs.adapter1 != "small_rna" ){
           return inputs.adapter1
         } else {
           return null
@@ -120,7 +120,7 @@ arguments:
   - prefix: --adapter2
     valueFrom: |
       ${
-        if ( inputs.fastq2 != null && inputs.apdater2 != null && inputs.adapter1 != "illumina" && inputs.adapter1 != "nextera" && inputs.adapter1 != "small_rna" ){
+        if ( inputs.fastq2 != null && inputs.adapter2 != null && inputs.adapter1 != "illumina" && inputs.adapter1 != "nextera" && inputs.adapter1 != "small_rna" ){
           return inputs.adapter2
         } else {
           return null


### PR DESCRIPTION
I think the original code would have stopped the input of any adapter choice which wasn't one of the predefined adapters. I've not tested this though (as I've not specified any adapters in my use case).